### PR TITLE
netbox 2.7 support in dcim

### DIFF
--- a/netbox/models/device_interface.go
+++ b/netbox/models/device_interface.go
@@ -62,9 +62,6 @@ type DeviceInterface struct {
 	// Enabled
 	Enabled bool `json:"enabled,omitempty"`
 
-	// form factor
-	FormFactor *DeviceInterfaceFormFactor `json:"form_factor,omitempty"`
-
 	// ID
 	// Read Only: true
 	ID int64 `json:"id,omitempty"`
@@ -101,6 +98,9 @@ type DeviceInterface struct {
 	// tags
 	Tags []string `json:"tags"`
 
+	// type
+	Type *DeviceInterfaceType `json:"type,omitempty"`
+
 	// untagged vlan
 	UntaggedVlan *NestedVLAN `json:"untagged_vlan,omitempty"`
 }
@@ -125,10 +125,6 @@ func (m *DeviceInterface) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateFormFactor(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateLag(formats); err != nil {
 		res = append(res, err)
 	}
@@ -150,6 +146,10 @@ func (m *DeviceInterface) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateTags(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -222,24 +222,6 @@ func (m *DeviceInterface) validateDevice(formats strfmt.Registry) error {
 		if err := m.Device.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("device")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *DeviceInterface) validateFormFactor(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.FormFactor) { // not required
-		return nil
-	}
-
-	if m.FormFactor != nil {
-		if err := m.FormFactor.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("form_factor")
 			}
 			return err
 		}
@@ -364,6 +346,24 @@ func (m *DeviceInterface) validateTags(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *DeviceInterface) validateType(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Type) { // not required
+		return nil
+	}
+
+	if m.Type != nil {
+		if err := m.Type.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("type")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *DeviceInterface) validateUntaggedVlan(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.UntaggedVlan) { // not required
@@ -467,73 +467,6 @@ func (m *DeviceInterfaceConnectionStatus) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-// DeviceInterfaceFormFactor Form factor
-// swagger:model DeviceInterfaceFormFactor
-type DeviceInterfaceFormFactor struct {
-
-	// label
-	// Required: true
-	Label *string `json:"label"`
-
-	// value
-	// Required: true
-	Value *int64 `json:"value"`
-}
-
-// Validate validates this device interface form factor
-func (m *DeviceInterfaceFormFactor) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateLabel(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateValue(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *DeviceInterfaceFormFactor) validateLabel(formats strfmt.Registry) error {
-
-	if err := validate.Required("form_factor"+"."+"label", "body", m.Label); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *DeviceInterfaceFormFactor) validateValue(formats strfmt.Registry) error {
-
-	if err := validate.Required("form_factor"+"."+"value", "body", m.Value); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// MarshalBinary interface implementation
-func (m *DeviceInterfaceFormFactor) MarshalBinary() ([]byte, error) {
-	if m == nil {
-		return nil, nil
-	}
-	return swag.WriteJSON(m)
-}
-
-// UnmarshalBinary interface implementation
-func (m *DeviceInterfaceFormFactor) UnmarshalBinary(b []byte) error {
-	var res DeviceInterfaceFormFactor
-	if err := swag.ReadJSON(b, &res); err != nil {
-		return err
-	}
-	*m = res
-	return nil
-}
-
 // DeviceInterfaceMode Mode
 // swagger:model DeviceInterfaceMode
 type DeviceInterfaceMode struct {
@@ -594,6 +527,73 @@ func (m *DeviceInterfaceMode) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *DeviceInterfaceMode) UnmarshalBinary(b []byte) error {
 	var res DeviceInterfaceMode
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// DeviceInterfaceType Type
+// swagger:model DeviceInterfaceType
+type DeviceInterfaceType struct {
+
+	// label
+	// Required: true
+	Label *string `json:"label"`
+
+	// value
+	// Required: true
+	Value *string `json:"value"`
+}
+
+// Validate validates this device interface type
+func (m *DeviceInterfaceType) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateLabel(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateValue(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *DeviceInterfaceType) validateLabel(formats strfmt.Registry) error {
+
+	if err := validate.Required("type"+"."+"label", "body", m.Label); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *DeviceInterfaceType) validateValue(formats strfmt.Registry) error {
+
+	if err := validate.Required("type"+"."+"value", "body", m.Value); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *DeviceInterfaceType) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *DeviceInterfaceType) UnmarshalBinary(b []byte) error {
+	var res DeviceInterfaceType
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/swagger.json
+++ b/swagger.json
@@ -17442,8 +17442,8 @@
           "maxLength": 64,
           "minLength": 1
         },
-        "form_factor": {
-          "title": "Form factor",
+        "type": {
+          "title": "Type",
           "required": [
             "label",
             "value"
@@ -17454,7 +17454,7 @@
               "type": "string"
             },
             "value": {
-              "type": "integer"
+              "type": "string"
             }
           }
         },

--- a/test/dcim/dcim_test.go
+++ b/test/dcim/dcim_test.go
@@ -1,0 +1,30 @@
+package dcim_test
+
+import (
+    "fmt"
+    runtimeclient "github.com/go-openapi/runtime/client"
+    "github.com/hosting-de-labs/go-netbox/netbox/client"
+    "os"
+    "testing"
+)
+
+const (
+    Host = "netbox.global.cloud.sap"
+    DeviceID = 290
+)
+
+var Token = os.Getenv("TOKEN")
+
+func TestDcim(t *testing.T) {
+    tlsClient, _ := runtimeclient.TLSClient(runtimeclient.TLSClientOptions{InsecureSkipVerify: true})
+
+    transport := runtimeclient.NewWithClient(Host, client.DefaultBasePath, []string{"https"}, tlsClient)
+    transport.DefaultAuthentication = runtimeclient.APIKeyAuth("Authorization", "header", fmt.Sprintf("Token %v", Token))
+
+    c := client.New(transport, nil)
+
+    interfaceListTest := &InterfaceListTest{DeviceID:DeviceID, C:*c }
+    if !t.Run("interfaceListTest", interfaceListTest.Run) {
+        return
+    }
+}

--- a/test/dcim/interface_list_test.go
+++ b/test/dcim/interface_list_test.go
@@ -1,0 +1,36 @@
+package dcim_test
+
+import (
+    "fmt"
+    "github.com/hosting-de-labs/go-netbox/netbox/client"
+    "github.com/hosting-de-labs/go-netbox/netbox/client/dcim"
+    "github.com/stretchr/testify/assert"
+    "reflect"
+
+    "testing"
+)
+
+type InterfaceListTest struct {
+    DeviceID int64
+    C   client.NetBox
+}
+
+func (k *InterfaceListTest) Run(t *testing.T) {
+    _ = t.Run("byDeviceID", k.ListInterfacesByDeviceID)
+}
+
+func (k *InterfaceListTest) ListInterfacesByDeviceID(t *testing.T) {
+    params := dcim.NewDcimInterfacesListParams()
+    params.SetDeviceID(&k.DeviceID)
+    //We want only type LAG so pass in 200
+    typ := "lag"
+    params.SetType(&typ)
+    res, err := k.C.Dcim.DcimInterfacesList(params, nil)
+    if err != nil {
+        fmt.Printf("err DcimInterfacesList: %v", err)
+        fmt.Printf("payload: %v", res)
+    }
+    fmt.Printf("DEBUG %v", res)
+    assert.NoError(t, err)
+    assert.True(t, reflect.TypeOf(res.Payload.Results[0].Type.Value).String() == "*string")
+}


### PR DESCRIPTION
- removes `form_factor` in device_interface (https://github.com/netbox-community/netbox/commit/15b55f5e628f33926fc3f14262ecdf9b59fa8bb1) 
- adds interfaces tests  for future use